### PR TITLE
Allow componentWillReceiveProps option to be a function

### DIFF
--- a/src/prepared.js
+++ b/src/prepared.js
@@ -22,7 +22,10 @@ const prepared = (prepare, {
     }
 
     componentWillReceiveProps(nextProps, nextContext) {
-      if(componentWillReceiveProps) {
+      if((
+        typeof componentWillReceiveProps === 'function'
+        && componentWillReceiveProps(this.props, nextProps, this.context, nextContext)
+      ) || componentWillReceiveProps) {
         prepare(nextProps, nextContext);
       }
     }


### PR DESCRIPTION
Gives you more control over which prop changes that should trigger the prepare function on componentWillReceiveProps.