### PR TITLE
Give `context` as a second argument when invoking stateless function component

### DIFF
--- a/src/prepare.js
+++ b/src/prepare.js
@@ -70,7 +70,7 @@ function prepareElement(element, context) {
     return Promise.resolve([props.children, context]);
   }
   if (!isReactCompositeComponent(type)) {
-    return Promise.resolve([type(props), context]);
+    return Promise.resolve([type(props, context), context]);
   }
   return prepareCompositeElement(element, context);
 }


### PR DESCRIPTION
Stateless function components get `context` as a second argument. I couldn't find official documentation for that but some libraries (e.g. `react-popper`) depend on it and crash without it.